### PR TITLE
ovirt-engine-setup: Fix for update setup packages

### DIFF
--- a/tasks/engine_setup.yml
+++ b/tasks/engine_setup.yml
@@ -24,9 +24,8 @@
     when: ovirt_engine_setup_answer_file_path is defined
 
   - name: Update setup packages
-    package:
-      name: "ovirt*setup*"
-      state: latest
+    # WA for https://github.com/ansible/ansible/issues/34867
+    command: yum -y update ovirt\*setup\*
     when: ovirt_engine_setup_update_setup_packages
 
   - name: Update all packages


### PR DESCRIPTION
Calling 'ovirt*setup*' will update and try to install also
non-installed packages, changing to ovirt*setup will only update
installed packages