### PR TITLE
Change ovirt_engine_setup_product_type parameter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ as ``ovirt_engine_setup_answer_file_path``.
 | Name                            | Default value         |  Description                                              |
 |---------------------------------|-----------------------|-----------------------------------------------------------|
 | ovirt_engine_setup_version            | 4.2                   | Allowed versions: [4.1, 4.2] |
-| ovirt_engine_setup_product_type       | ovirt-engine          | Type of product 'ovirt-engine' or 'rhvm'  |
-| ovirt_engine_setup_package_list       | []                    |  List of extra packages to be installed on engine apart from ovirt-engine package. |
+| ovirt_engine_setup_product_type       | oVirt                 | One of ["oVirt", "RHV"], case insensitive. |
+| ovirt_engine_setup_package_list       | []                    | List of extra packages to be installed on engine apart from ovirt-engine package. |
 | ovirt_engine_setup_answer_file_path   | UNDEF                 | Path to custom answerfile for `engine-setup`. |
 | ovirt_engine_setup_organization       | UNDEF                 | Organization name for certificate. |
 | ovirt_engine_setup_firewall_manager   | firewalld             | Specify the type of firewall manager to configure on Engine host, following values are availableL: `firewalld`,`iptables` or empty value to skip firewall configuration. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,5 +23,5 @@ ovirt_engine_setup_firewall_manager: 'firewalld'
 ovirt_engine_setup_update_all_packages: true
 ovirt_engine_setup_update_setup_packages: false
 
-ovirt_engine_setup_product_type: ovirt-engine
+ovirt_engine_setup_product_type: oVirt
 ovirt_engine_setup_package_list: []

--- a/tasks/install_packages.yml
+++ b/tasks/install_packages.yml
@@ -1,7 +1,10 @@
 ---
-- name: Install ovirt-engine/rhvm package
+- name: Install oVirt Engine packages.
   package:
-    name: "{{ ovirt_engine_setup_product_type }}"
+    name: "{{ ('ovirt-engine'
+                  if ovirt_engine_setup_product_type|lower == 'ovirt'
+                  else ('rhevm' if ovirt_engine_setup_version|float < 4.2 else 'rhvm')
+              ) }}"
     state: present
 
 - name: Install rest of the packages required for oVirt Engine deployment


### PR DESCRIPTION
Since in versions <=4.1 package alias for ovirt-engine is rhevm
it should be documented as supported product type.