### PR TITLE
Remove WA for yum and fix linters.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ services:
 env:
   global:
     - ANSIBLE_HOST_KEY_CHECKING="False"
+    - ANSIBLE_ROLES_PATH=tests/roles:tests/roles-deps
   matrix:
     - TEST_NAME=4.1
     - TEST_NAME=master
@@ -30,7 +31,7 @@ install:
   - ansible --version
 
   # Install ansible role tests requirements
-  - ansible-galaxy install -r tests/requirements.yml -p tests/roles/
+  - ansible-galaxy install -r tests/requirements.yml -p tests/roles-deps/
 
 script:
   # Run sytax checks and linters

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Requirements
 ------------
 
  * Environment with configured repositories.
- * Ansible version 2.4
+ * Ansible version 2.5
 
 Role Variables
 --------------

--- a/tasks/engine_setup.yml
+++ b/tasks/engine_setup.yml
@@ -24,8 +24,9 @@
     when: ovirt_engine_setup_answer_file_path is defined
 
   - name: Update setup packages
-    # WA for https://github.com/ansible/ansible/issues/34867
-    command: yum -y update ovirt\*setup\*
+    yum:
+      name: "update ovirt*setup*"
+      update_only: true
     when: ovirt_engine_setup_update_setup_packages
     tags:
       - "skip_ansible_lint"  # ANSIBLE0006

--- a/tox.ini
+++ b/tox.ini
@@ -7,26 +7,23 @@ deps =
         -r{toxinidir}/requirements.txt
         -r{toxinidir}/test-requirements.txt
 whitelist_externals = bash
-
+setenv =
+        ANSIBLE_ROLES_PATH={toxinidir}/tests/roles:{toxinidir}/tests/roles-deps
 
 [testenv:ansible-lint]
-commands = bash -c "\
-        ansible-lint "{toxinidir}"/tests/test*.yml"
+commands = bash -c \
+        "ansible-lint --exclude={toxinidir}/tests/roles-deps {toxinidir}/tests/test*.yml"
 
 [testenv:yamllint]
-commands = bash -c "\
-        yamllint \
-                -c {toxinidir}/.yamllint \
-                {toxinidir}/tasks \
-                {toxinidir}/tests/*.yml"
+commands = bash -c \
+        "yamllint -c {toxinidir}/.yamllint {toxinidir}/tasks {toxinidir}/tests/*.yml"
 
 [testenv:ansible-syntax]
-commands = bash -c "\
-        ansible-galaxy install -r tests/requirements.yml -p tests/roles/; \
-        ansible-playbook \
-                --syntax-check \
-                --list-tasks \
-                {toxinidir}/tests/test*.yml"
+commands =
+        bash -c \
+            "ansible-galaxy install -r {toxinidir}/tests/requirements.yml -p {toxinidir}/tests/roles-deps/"
+        bash -c \
+            "ansible-playbook --syntax-check --list-tasks {toxinidir}/tests/test*.yml"
 
 [testenv:linters]
 commands =


### PR DESCRIPTION
Yum module now provides update_only option.

Linters:
Posted PR here: https://github.com/chrismeyersfsu/provision_docker/pull/70
In tox it was changed to not test roles downloaded as deps.

Align travis conf file for deps in different folder.