### PR TITLE
Add answerfile-path-on-remote option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ as ``ovirt_engine_setup_answer_file_path``.
 | ovirt_engine_setup_product_type       | oVirt                 | One of ["oVirt", "RHV"], case insensitive. |
 | ovirt_engine_setup_package_list       | []                    | List of extra packages to be installed on engine apart from ovirt-engine package. |
 | ovirt_engine_setup_answer_file_path   | UNDEF                 | Path to custom answerfile for `engine-setup`. |
+| ovirt_engine_setup_use_remote_answer_file | UNDEF             | If `True`, use answerfile's path on the remote machine. This option should be used if the installation occure on the remote machine and the answerfile is located on there also. |
 | ovirt_engine_setup_organization       | UNDEF                 | Organization name for certificate. |
 | ovirt_engine_setup_firewall_manager   | firewalld             | Specify the type of firewall manager to configure on Engine host, following values are availableL: `firewalld`,`iptables` or empty value to skip firewall configuration. |
 | ovirt_engine_setup_update_setup_packages | False              | If `True`, setup packages will be updated before `engine-setup` will be executed. Makes sense if Engine is already installed. |

--- a/tasks/engine_setup.yml
+++ b/tasks/engine_setup.yml
@@ -20,7 +20,12 @@
       mode: 0600
       owner: root
       group: root
-    when: ovirt_engine_setup_answer_file_path is defined
+    when: ovirt_engine_setup_answer_file_path is defined and ( ovirt_engine_setup_use_remote_answer_file is undefined or not ovirt_engine_setup_use_remote_answer_file )
+
+  - name: Use remote's answer file
+    set_fact:
+      answer_file_path: "{{ ovirt_engine_setup_answer_file_path }}"
+    when: ovirt_engine_setup_use_remote_answer_file
 
   - name: Update setup packages
     yum:

--- a/tasks/engine_setup.yml
+++ b/tasks/engine_setup.yml
@@ -20,7 +20,7 @@
       mode: 0600
       owner: root
       group: root
-    when: ovirt_engine_setup_answer_file_path is defined and ( ovirt_engine_setup_use_remote_answer_file is undefined or not ovirt_engine_setup_use_remote_answer_file )
+    when: ovirt_engine_setup_answer_file_path is defined and ( ovirt_engine_setup_use_remote_answer_file is not defined or not ovirt_engine_setup_use_remote_answer_file )
 
   - name: Use remote's answer file
     set_fact:


### PR DESCRIPTION
Support using an answerfile's path which located on a remote machine
rather on localhost.

An example use case:
Hosted-engine-setup install engine-setup with ovirt-engine-appliance
which has the answerfile located inside of it.