### PR TITLE
update_only has an effect only if state is latest

### DIFF
--- a/tasks/engine_setup.yml
+++ b/tasks/engine_setup.yml
@@ -31,6 +31,7 @@
     yum:
       name: "ovirt*setup*"
       update_only: true
+      state: latest
     when: ovirt_engine_setup_update_setup_packages
     tags:
       - "skip_ansible_lint"  # ANSIBLE0006


### PR DESCRIPTION
Regarding to doc:
https://docs.ansible.com/ansible/2.5/modules/yum_module.html
We have to use state: latest. I tried it and without this param, it really
doesn't update packages.