### PR TITLE
Fix installation of rhvm package in upgrade

### DIFF
--- a/tasks/install_packages.yml
+++ b/tasks/install_packages.yml
@@ -5,11 +5,17 @@
     state: present
   when: ovirt_engine_setup_product_type | lower == 'ovirt'
 
+- name: Check if rhevm package is installed
+  yum:
+    list: "rhevm"
+  when: ovirt_engine_setup_product_type | lower == 'rhv' and ansible_os_family == 'RedHat'
+  register: rhevm_installed
+
 - name: Install RHV package
   package:
     name: "{{ 'rhevm' if ovirt_engine_setup_version is version('4.2', '<') else 'rhvm' }}"
     state: present
-  when: ovirt_engine_setup_product_type | lower == 'rhv'
+  when: ovirt_engine_setup_product_type | lower == 'rhv' and rhevm_installed.results | default([]) | selectattr('yumstate', 'match', 'installed') | list | length == 0
 
 - name: Install rest of the packages required for oVirt Engine deployment
   package:


### PR DESCRIPTION
Once there is installed rhevm package from 4.1 version, during the
upgrade we cannot install package rhvm cause it's missing in the list
probably because of yum versionlock plugin.

So we can check if it's installed, and if not we can process with
installation otherwise we can skip the installation.

Fixing issue #33 