### PR TITLE
remove default value of ovirt_engine_setup_accept_defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 ovirt_engine_setup_version: '4.2'
-ovirt_engine_setup_accept_defaults: false
 
 ovirt_engine_setup_provider_ovn_configure: true
 ovirt_engine_setup_provider_ovn_username: 'admin@internal'


### PR DESCRIPTION
in continuouse to PR "Fix upgrade flow":
    https://github.com/oVirt/ovirt-ansible-engine-setup/pull/35
need to remove the default value of ovirt_engine_setup_accept_defaults
since it's not in use anymore.