### PR TITLE
get ready for delegate_to

### DIFF
--- a/tasks/engine_setup.yml
+++ b/tasks/engine_setup.yml
@@ -61,7 +61,7 @@
 
   - name: Check if Engine health page is up
     uri:
-      url: "http://{{ ansible_fqdn }}/ovirt-engine/services/health"
+      url: "http://localhost/ovirt-engine/services/health"
       status_code: 200
     register: health_page
     retries: 12


### PR DESCRIPTION
ovirt.hosted_engine_setup want's to
statically import this role on the
engine VM via delegate_to but
ansible_fqdn is breaking it.
Using just 'localhost' is enough.