### PR TITLE
automation: drop Fedora 27 builds

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,6 +1,5 @@
 distros:
   - fc28
-  - fc27
   - el7
 release_branches:
   master: [ "ovirt-master", "ovirt-4.2" ]


### PR DESCRIPTION
Fedora 27 reached EOL long time ago.