### PR TITLE
Allow setting custom FQDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ as ``ovirt_engine_setup_answer_file_path``.
 | ovirt_engine_setup_package_list       | []                    | List of extra packages to be installed on engine apart from ovirt-engine package. |
 | ovirt_engine_setup_answer_file_path   | UNDEF                 | Path to custom answerfile for `engine-setup`. |
 | ovirt_engine_setup_use_remote_answer_file | false             | If `True`, use answerfile's path on the remote machine. This option should be used if the installation occure on the remote machine and the answerfile is located on there also. |
+| ovirt_engine_setup_fqdn               | UNDEF                 | Host fully qualified DNS name of the server. |
 | ovirt_engine_setup_organization       | UNDEF                 | Organization name for certificate. |
 | ovirt_engine_setup_firewall_manager   | firewalld             | Specify the type of firewall manager to configure on Engine host, following values are availableL: `firewalld`,`iptables` or empty value to skip firewall configuration. |
 | ovirt_engine_setup_update_setup_packages | False              | If `True`, setup packages will be updated before `engine-setup` will be executed. Makes sense if Engine is already installed. |

--- a/templates/basic_answerfile.txt.j2
+++ b/templates/basic_answerfile.txt.j2
@@ -1,4 +1,7 @@
 [environment:default]
+{% if ovirt_engine_setup_fqdn %}
+OVESETUP_CONFIG/fqdn=str:{{ ovirt_engine_setup_fqdn }}
+{% endif %}
 {% if ovirt_engine_setup_firewall_manager %}
 OVESETUP_CONFIG/updateFirewall=bool:True
 OVESETUP_CONFIG/firewallManager=str:{{ ovirt_engine_setup_firewall_manager }}


### PR DESCRIPTION
During the interactive installation it is possible to specify
a custom FQDN instead of using an autodetected host name. This is
especially useful when using virtual hosts on the server hosting
oVirt Engine.

This patch allows setting ovirt_engine_setup_fqdn variable which
will be used during the installation process to set the value to
a desired one.

Closes-bug: #49