### PR TITLE
add is defined in the json condition to prevent undefined param failure

### DIFF
--- a/templates/basic_answerfile.txt.j2
+++ b/templates/basic_answerfile.txt.j2
@@ -1,5 +1,5 @@
 [environment:default]
-{% if ovirt_engine_setup_fqdn %}
+{% if ovirt_engine_setup_fqdn is defined %}
 OVESETUP_CONFIG/fqdn=str:{{ ovirt_engine_setup_fqdn }}
 {% endif %}
 {% if ovirt_engine_setup_firewall_manager %}


### PR DESCRIPTION
Since this parameter undefined by default we got the following error:
12:29:13 TASK [ovirt.engine-setup : Use the default answerfile] *************************
12:29:13 fatal: [example.host.com]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'ovirt_engine_setup_fqdn' is undefined"}
