### PR TITLE
ovirt-ansible-engine-setup: bump ansible to 2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Requirements
 ------------
 
  * Environment with configured repositories.
- * Ansible version 2.7.2
+ * Ansible version 2.9.0
 
 Role Variables
 --------------

--- a/automation.yaml
+++ b/automation.yaml
@@ -1,6 +1,5 @@
 distros:
   - fc30
   - el7
-  - el8
 release_branches:
   master: [ "ovirt-master" ]

--- a/automation.yaml
+++ b/automation.yaml
@@ -1,5 +1,4 @@
 distros:
-  - fc29
   - fc30
   - el7
   - el8

--- a/automation.yaml
+++ b/automation.yaml
@@ -4,4 +4,4 @@ distros:
   - el7
   - el8
 release_branches:
-  master: [ "ovirt-master", "ovirt-4.3" ]
+  master: [ "ovirt-master" ]

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="1.1.10"
+VERSION="1.2.0"
 MILESTONE=master
 RPM_RELEASE="0.1.$MILESTONE.$(date -u +%Y%m%d%H%M%S)"
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: Apache License 2.0
 
-  min_ansible_version: 2.5
+  min_ansible_version: 2.9
 
   platforms:
   - name: EL

--- a/ovirt-ansible-engine-setup.spec.in
+++ b/ovirt-ansible-engine-setup.spec.in
@@ -13,7 +13,7 @@ Group:          Virtualization/Management
 BuildArch:      noarch
 Url:            http://www.ovirt.org
 
-Requires: ansible >= 2.7.2
+Requires: ansible >= 2.9.0
 
 %description
 This Ansible role installs required packages for oVirt Engine deployment,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible
+ansible>=2.9.0


### PR DESCRIPTION
Bump ansible to 2.9
- keep only "ovirt-master" in automation.yaml    
- bump project version to 1.2.0
- change in all tasks *_facts to *_info modules because of depreciation in ansible 2.13
   - it cannot be simply renamed to _info module because it does not return ansible_facts so all variables need to be registered and then used (https://docs.ansible.com/ansible/latest/modules/ovirt_api_info_module.html#notes)
- remove all unnecessary libraries and update tasks to match from ansible 2.9 and not lib 
- use ansible>=2.9.0 in 
  - ovirt-ansible-engine-setup.spec.in for build  
  - requirements.txt for manual install of ansible from pip
  - meta/main.yml for info in ansible galaxy
  - change ansible version in  README.md

https://bugzilla.redhat.com/show_bug.cgi?id=1762259
@machacekondra @mwperina