### PR TITLE
Raise health page check retries

### DIFF
--- a/tasks/engine_setup.yml
+++ b/tasks/engine_setup.yml
@@ -68,7 +68,7 @@
       url: "http://localhost/ovirt-engine/services/health"
       status_code: 200
     register: health_page
-    retries: 12
+    retries: 30
     delay: 10
     until: health_page is success
 


### PR DESCRIPTION
On OST system is very slow and deployment fails on engine not yet up after 12 tries.
In Hosted Engine deployment we raised to 30 retires trying to cover for this slow system deployment within OST.
Doing the same here.