### PR TITLE
Use only one parameter for package updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,8 @@ as ``ovirt_engine_setup_answer_file_path``.
 | ovirt_engine_setup_use_remote_answer_file | False             | If `True`, use answerfile's path on the remote machine. This option should be used if the installation occure on the remote machine and the answerfile is located on there also. |
 | ovirt_engine_setup_update_setup_packages | False              | If `True`, setup packages will be updated before `engine-setup` will be executed. Makes sense if Engine is already installed. |
 | ovirt_engine_setup_perform_upgrade    | False                 | If `True` this role is used to perform upgrade. |
-| ovirt_engine_setup_update_all_packages | True                 | If `True`, all packages will be updated before `engine-setup` will be executed, `ovirt_engine_setup_offline` needs to be `False` to update packages. |
 | ovirt_engine_setup_product_type       | oVirt                 | One of ["oVirt", "RHV"], case insensitive. |
-| ovirt_engine_setup_offline            | False                 | If `True`, `engine-setup` will not search for package updates. |
+| ovirt_engine_setup_offline            | False                 | If `True`, updates for all packages will be disabled |
 
 * Common options for engine:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,6 @@ ovirt_engine_setup_firewall_manager: 'firewalld'
 
 # This option is suggested from oVirt Documentation
 # https://www.ovirt.org/documentation/install-guide/chap-Installing_oVirt/
-ovirt_engine_setup_update_all_packages: true
 ovirt_engine_setup_update_setup_packages: false
 ovirt_engine_setup_offline: false
 

--- a/tasks/engine_setup.yml
+++ b/tasks/engine_setup.yml
@@ -45,13 +45,13 @@
     package:
       name: "*"
       state: latest
-    when: ovirt_engine_setup_update_all_packages|bool and not ovirt_engine_setup_offline|bool
+    when: not ovirt_engine_setup_offline|bool
     tags:
       - "skip_ansible_lint"  # ANSIBLE0010
 
   - name: Set offline parameter if variable is set
     set_fact:
-      offline: "{{ '--offline' if ovirt_engine_setup_offline else '' }}"
+      offline: "{{ '--offline' if ovirt_engine_setup_offline|bool else '' }}"
 
   - name: Run engine-setup with answerfile
     command: "engine-setup --accept-defaults --config-append={{ answer_file_path }} {{ offline }}"


### PR DESCRIPTION
- Use only `ovirt_engine_setup_offline` parameter for package updates
  and remove `ovirt_engine_setup_update_all_packages` parameter
- Fix if statement for `offline` fact
- Update README

Signed-off-by: Asaf Rachmani <arachman@redhat.com>