### PR TITLE
Add OVESETUP_IGNORE_SNAPSHOTS_WITH_OLD_COMPAT_LEVEL to 4.3

### DIFF
--- a/templates/answerfile_4.3_basic.txt.j2
+++ b/templates/answerfile_4.3_basic.txt.j2
@@ -8,3 +8,4 @@ QUESTION/1/OVESETUP_APACHE_CONFIG_ROOT_REDIRECTION=str:{{ ovirt_engine_apache_co
 {% if ovirt_engine_apache_config_ssl is defined %}
 QUESTION/1/OVESETUP_APACHE_CONFIG_SSL=str:{{ ovirt_engine_apache_config_ssl | ternary('automatic','manual') }}
 {% endif %}
+QUESTION/1/OVESETUP_IGNORE_SNAPSHOTS_WITH_OLD_COMPAT_LEVEL=str:yes


### PR DESCRIPTION
Add to 4.3 answer file 
QUESTION/1/OVESETUP_IGNORE_SNAPSHOTS_WITH_OLD_COMPAT_LEVEL=str:yes
issue: https://bugzilla.redhat.com/show_bug.cgi?id=1822535
@mwperina @dangel101