### PR TITLE
remove redundant variables from tests and examples

### DIFF
--- a/examples/engine-deploy.yml
+++ b/examples/engine-deploy.yml
@@ -6,7 +6,6 @@
   vars:
     ovirt_engine_setup_product_type: 'ovirt'
     ovirt_engine_setup_version: "4.2"
-    ovirt_engine_setup_hostname: "localhost"
     ovirt_engine_setup_organization: "example.com"
     ovirt_engine_setup_dwh_db_host: "localhost"
     ovirt_engine_setup_configure_iso_domain: true

--- a/examples/engine-upgrade.yml
+++ b/examples/engine-upgrade.yml
@@ -6,7 +6,6 @@
   vars:
     ovirt_engine_setup_product_type: "ovirt"
     ovirt_engine_setup_version: "{{ ovirt_engine_setup_version }}"
-    ovirt_engine_setup_hostname: "localhost"
     ovirt_engine_setup_organization: "example.com"
     ovirt_engine_setup_configure_iso_domain: true
     ovirt_engine_setup_firewall_manager: null

--- a/tests/engine-deploy.yml
+++ b/tests/engine-deploy.yml
@@ -4,9 +4,7 @@
   vars_files:
     - passwords.yml
   vars:
-    ovirt_engine_setup_type: "ovirt-engine"
     ovirt_engine_setup_version: "{{ ovirt_engine_setup_version }}"
-    ovirt_engine_setup_hostname: "localhost"
     ovirt_engine_setup_organization: "example.com"
     ovirt_engine_setup_dwh_db_configure: true
     ovirt_engine_setup_dwh_db_host: "localhost"

--- a/tests/engine-upgrade.yml
+++ b/tests/engine-upgrade.yml
@@ -4,9 +4,7 @@
   vars_files:
     - passwords.yml
   vars:
-    ovirt_engine_setup_type: "ovirt-engine"
     ovirt_engine_setup_version: "{{ ovirt_engine_setup_version }}"
-    ovirt_engine_setup_hostname: "localhost"
     ovirt_engine_setup_organization: "example.com"
     ovirt_engine_setup_firewall_manager: null
     ovirt_engine_setup_dwh_db_configure: false


### PR DESCRIPTION
we no longer use the following variables:
 - ovirt_engine_setup_type
 - ovirt_engine_setup_hostname