### PR TITLE
Add ovirt_engine_grafana_enable and ovirt_engine_overwrite_pki_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ to ``ovirt_engine_setup_answer_file_path`` variable.
 | ovirt_engine_setup_admin_password     | UNDEF                 | Password for the automatically created administrative user of the oVirt Engine.
 | ovirt_engine_setup_wait_running_tasks | False                 | If `True`, engine-setup will wait for running tasks to finish. Valid for `ovirt_engine_setup_version` >= 4.2. |
 | ovirt_engine_cinderlib_enable         | False                 | If `True`, cinderlib is enabled. Valid for `ovirt_engine_setup_version` >= 4.3. |
+| ovirt_engine_grafana_enable           | True                  | If `True`, Grafana integration will be set up. Valid for `ovirt_engine_setup_version` >= 4.4. |
 | ovirt_engine_setup_engine_configs     | []                    | List of dictionaries with keys `key`, `value` and `version`. The engine-config will be called with parametrs "-s `key`=`value`" when specified `version` it will append "--cver=`version`" to the config.  |
 
 * Engine Database:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,8 @@ ovirt_engine_setup_dwh_db_name: 'ovirt_engine_history'
 ovirt_engine_setup_dwh_db_user: 'ovirt_engine_history'
 ovirt_engine_setup_dwh_vacuum_full: false
 
+ovirt_engine_grafana_enable: true
+
 ovirt_engine_setup_firewall_manager: 'firewalld'
 
 # This option is suggested from oVirt Documentation

--- a/templates/answerfile_4.4_basic.txt.j2
+++ b/templates/answerfile_4.4_basic.txt.j2
@@ -1,1 +1,3 @@
 {% include "./templates/answerfile_4.3_basic.txt.j2" %}
+
+OVESETUP_GRAFANA_CORE/enable=bool:{{ ovirt_engine_grafana_enable }}


### PR DESCRIPTION
This PR provides two variables that allow users:
- Not to set up Grafana in order to speed up the deploy
- Overwrite existing PKI files. This is useful in case you run the role against a machine where oVirt engine lived before. `engine-cleanup` leaves behing some leftover files. Unless you explicitly specify that you're okay with overwriting them, the setup will be aborted. 